### PR TITLE
Add services section and enhance skills list

### DIFF
--- a/src/app/page.js
+++ b/src/app/page.js
@@ -6,12 +6,14 @@ import {
   HeroSection,
   LanguagesSection,
   ProjectsSection,
+  ServicesSection,
   SkillsSection,
 } from "@/components/home";
 
 const navLinks = [
   { href: "#about", label: "About" },
   { href: "#experience", label: "Experience" },
+  { href: "#services", label: "Services" },
   { href: "#projects", label: "Projects" },
   { href: "#skills", label: "Skills" },
   { href: "#languages", label: "Languages" },
@@ -47,6 +49,7 @@ export default function Home() {
         <HeroSection />
         <AboutSection />
         <ExperienceSection />
+        <ServicesSection />
         <ProjectsSection />
         <SkillsSection />
         <LanguagesSection />

--- a/src/components/home/index.js
+++ b/src/components/home/index.js
@@ -4,5 +4,6 @@ export { EducationSection } from "./education-section";
 export { ExperienceSection } from "./experience-section";
 export { HeroSection } from "./hero-section";
 export { ProjectsSection } from "./projects-section";
+export { ServicesSection } from "./services-section";
 export { SkillsSection } from "./skills-section";
 export { LanguagesSection } from "./languages-section";

--- a/src/components/home/services-section.js
+++ b/src/components/home/services-section.js
@@ -1,0 +1,51 @@
+import { SectionHeader } from "@/components/section-header";
+import { Card } from "@/components/ui/card";
+import { LayoutTemplate, ShoppingCart, Workflow } from "lucide-react";
+
+const services = [
+  {
+    title: "Advanced Web Applications",
+    description:
+      "Deliver complex, data-heavy apps with robust business logic, real-time UX, and scalable backends.",
+    icon: Workflow,
+  },
+  {
+    title: "Custom Ecommerce Platforms",
+    description:
+      "Craft tailored storefronts with custom catalogs, checkout flows, and integrations beyond off-the-shelf themes.",
+    icon: ShoppingCart,
+  },
+  {
+    title: "WordPress Experience Sites",
+    description:
+      "Design and build WordPress themes and blocks that stay fast, secure, and simple for teams to update.",
+    icon: LayoutTemplate,
+  },
+];
+
+export function ServicesSection() {
+  return (
+    <section id="services" className="space-y-8">
+      <SectionHeader
+        eyebrow="SERVICES"
+        title="How I can help"
+        description="End-to-end delivery for startups and teams that need polished apps, ecommerce experiences, and WordPress builds."
+      />
+      <div className="grid gap-5 md:grid-cols-3">
+        {services.map(({ title, description, icon: Icon }) => (
+          <Card key={title} className="h-full border-white/10 bg-white/[0.04] p-6">
+            <div className="flex h-full flex-col gap-5">
+              <span className="flex h-12 w-12 items-center justify-center rounded-full bg-sky-400/10 text-sky-400">
+                <Icon className="h-6 w-6" aria-hidden />
+              </span>
+              <div className="space-y-2">
+                <h3 className="text-lg font-semibold text-white">{title}</h3>
+                <p className="text-sm text-slate-300">{description}</p>
+              </div>
+            </div>
+          </Card>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/home/skills-section.js
+++ b/src/components/home/skills-section.js
@@ -1,31 +1,57 @@
 import { SectionHeader } from "@/components/section-header";
 import { Card } from "@/components/ui/card";
+import {
+  Atom,
+  Blocks,
+  Braces,
+  CircleDot,
+  Cloud,
+  Code,
+  Database,
+  FileCode2,
+  FileType2,
+  GitBranch,
+  Kanban,
+  Layers,
+  Leaf,
+  Network,
+  Octagon,
+  Palette,
+  PenTool,
+  Route,
+  Server,
+  ShieldCheck,
+  Terminal,
+  TestTube,
+  Triangle,
+  Wind,
+} from "lucide-react";
 
 const skills = [
-  "HTML5",
-  "CSS3",
-  "JavaScript (ES6+)",
-  "TypeScript",
-  "React.js",
-  "Next.js",
-  "Vue.js",
-  "AngularJS",
-  "Node.js",
-  "Express.js",
-  "PHP",
-  "Laravel",
-  "WordPress",
-  "AWS",
-  "RESTful APIs",
-  "MySQL",
-  "MongoDB",
-  "Supabase",
-  "Tailwind CSS",
-  "Bootstrap",
-  "Git & GitHub",
-  "Linux",
-  "Unit & Integration Testing",
-  "Agile & Scrum",
+  { name: "HTML5", icon: Code },
+  { name: "CSS3", icon: Palette },
+  { name: "JavaScript (ES6+)", icon: Braces },
+  { name: "TypeScript", icon: FileType2 },
+  { name: "React.js", icon: Atom },
+  { name: "Next.js", icon: CircleDot },
+  { name: "Vue.js", icon: Triangle },
+  { name: "AngularJS", icon: Octagon },
+  { name: "Node.js", icon: Server },
+  { name: "Express.js", icon: Route },
+  { name: "PHP", icon: FileCode2 },
+  { name: "Laravel", icon: Layers },
+  { name: "WordPress", icon: PenTool },
+  { name: "AWS", icon: Cloud },
+  { name: "RESTful APIs", icon: Network },
+  { name: "MySQL", icon: Database },
+  { name: "MongoDB", icon: Leaf },
+  { name: "Supabase", icon: ShieldCheck },
+  { name: "Tailwind CSS", icon: Wind },
+  { name: "Bootstrap", icon: Blocks },
+  { name: "Git & GitHub", icon: GitBranch },
+  { name: "Linux", icon: Terminal },
+  { name: "Unit & Integration Testing", icon: TestTube },
+  { name: "Agile & Scrum", icon: Kanban },
 ];
 
 export function SkillsSection() {
@@ -37,12 +63,15 @@ export function SkillsSection() {
         description="Frameworks, databases, and practices I reach for in full-stack delivery."
       />
       <div className="grid gap-3 sm:grid-cols-2 md:grid-cols-3">
-        {skills.map((skill) => (
+        {skills.map(({ name, icon: Icon }) => (
           <Card
-            key={skill}
-            className="border-white/10 bg-white/[0.04] p-4 text-center text-sm font-medium text-slate-200"
+            key={name}
+            className="flex items-center gap-3 border-white/10 bg-white/[0.04] p-4 text-left text-sm font-medium text-slate-200"
           >
-            {skill}
+            <span className="flex h-10 w-10 items-center justify-center rounded-full bg-sky-400/10 text-sky-400">
+              <Icon className="h-5 w-5" aria-hidden />
+            </span>
+            <span>{name}</span>
           </Card>
         ))}
       </div>


### PR DESCRIPTION
## Summary
- add a services section that highlights advanced web apps first with supporting cards and icons
- update the home page navigation and layout to surface the new services section
- enrich the skills grid with lucide icons for quicker scanning

## Testing
- NEXT_DISABLE_FONT_OPTIMIZATION=1 npm run build *(fails: unable to download Google Fonts in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68cacbaee6d08325a11ae51bd287fbbd