### PR TITLE
Improve education and experience layouts

### DIFF
--- a/src/components/home/education-section.js
+++ b/src/components/home/education-section.js
@@ -67,50 +67,44 @@ export function EducationSection() {
         title="Education & certifications"
         description="Academic foundations and professional credentials that inform my engineering approach."
       />
-      <div className="relative">
-        <div
-          className="absolute left-3 top-1 hidden h-full w-px bg-gradient-to-b from-sky-500/50 via-white/10 to-transparent md:block"
-          aria-hidden
-        />
-        <ol className="space-y-6">
-          {education.map((item) => (
-            <li key={`${item.school}-${item.degree}-${item.period}`} className="group relative md:pl-12">
+      <ol className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+        {education.map((item) => (
+          <li key={`${item.school}-${item.degree}-${item.period}`} className="h-full">
+            <Card className="relative flex h-full flex-col overflow-hidden border-white/10 bg-white/[0.04] shadow-[0_0_0_1px_rgba(148,163,184,0.08)] transition hover:border-sky-400/40 hover:bg-white/[0.06]">
               <span
-                className="absolute left-2 top-9 hidden h-3 w-3 rounded-full border-2 border-sky-400 bg-slate-950 transition group-hover:border-sky-300 group-hover:bg-sky-400/30 md:block"
+                className="absolute inset-y-0 left-0 w-1 bg-gradient-to-b from-sky-400/70 via-sky-400/20 to-transparent"
                 aria-hidden
               />
-              <Card className="border-white/10 bg-white/[0.035] p-0 shadow-[0_0_0_1px_rgba(148,163,184,0.12)] transition hover:border-sky-400/40 hover:bg-white/[0.05]">
-                <CardHeader className="mb-0 gap-3 p-6 pb-4">
-                  <div className="flex flex-wrap items-start justify-between gap-4">
-                    <CardTitle className="text-lg font-semibold text-white">
-                      {item.school}
-                    </CardTitle>
-                    <span className="flex items-center gap-2 rounded-full border border-sky-400/30 bg-sky-400/10 px-3 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-sky-100">
-                      <Calendar className="h-3.5 w-3.5" aria-hidden />
-                      {item.period}
-                    </span>
-                  </div>
-                  <CardDescription className="text-sm text-slate-300">
-                    {item.degree}
-                  </CardDescription>
-                </CardHeader>
-                {item.notes && item.notes.length > 0 ? (
-                  <CardContent className="gap-3 p-6 pt-0 text-sm text-slate-200">
-                    <ul className="space-y-2">
-                      {item.notes.map((note) => (
-                        <li key={note} className="flex gap-3 leading-relaxed">
-                          <span className="mt-2 h-1.5 w-1.5 flex-none rounded-full bg-sky-400/80" />
-                          <span>{note}</span>
-                        </li>
-                      ))}
-                    </ul>
-                  </CardContent>
-                ) : null}
-              </Card>
-            </li>
-          ))}
-        </ol>
-      </div>
+              <CardHeader className="flex-1 space-y-3 p-5 pb-4">
+                <div className="flex items-start justify-between gap-4">
+                  <CardTitle className="text-base font-semibold leading-tight text-white">
+                    {item.school}
+                  </CardTitle>
+                  <span className="inline-flex items-center gap-2 rounded-full border border-sky-400/30 bg-sky-400/10 px-3 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-sky-100">
+                    <Calendar className="h-3 w-3" aria-hidden />
+                    {item.period}
+                  </span>
+                </div>
+                <CardDescription className="text-sm text-slate-300">
+                  {item.degree}
+                </CardDescription>
+              </CardHeader>
+              {item.notes && item.notes.length > 0 ? (
+                <CardContent className="p-5 pt-0 text-xs text-slate-200">
+                  <ul className="space-y-1.5">
+                    {item.notes.map((note) => (
+                      <li key={note} className="flex gap-2 leading-relaxed">
+                        <span className="mt-1 h-1.5 w-1.5 flex-none rounded-full bg-sky-400/80" />
+                        <span>{note}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </CardContent>
+              ) : null}
+            </Card>
+          </li>
+        ))}
+      </ol>
     </section>
   );
 }

--- a/src/components/home/education-section.js
+++ b/src/components/home/education-section.js
@@ -67,30 +67,49 @@ export function EducationSection() {
         title="Education & certifications"
         description="Academic foundations and professional credentials that inform my engineering approach."
       />
-      <div className="grid gap-6 md:grid-cols-2">
-        {education.map((item) => (
-          <Card key={`${item.school}-${item.degree}-${item.period}`} className="border-white/10 bg-white/[0.035]">
-            <CardHeader className="mb-3 gap-2">
-              <CardTitle className="text-lg text-white">{item.school}</CardTitle>
-              <CardDescription className="text-sm text-slate-400">{item.degree}</CardDescription>
-              <p className="flex items-center gap-2 text-xs uppercase tracking-[0.2em] text-slate-500">
-                <Calendar className="h-4 w-4" aria-hidden />
-                {item.period}
-              </p>
-            </CardHeader>
-            {item.notes && item.notes.length > 0 ? (
-              <CardContent className="gap-3 text-sm text-slate-300">
-                <ul className="space-y-2">
-                  {item.notes.map((note) => (
-                    <li key={note} className="leading-relaxed">
-                      {note}
-                    </li>
-                  ))}
-                </ul>
-              </CardContent>
-            ) : null}
-          </Card>
-        ))}
+      <div className="relative">
+        <div
+          className="absolute left-3 top-1 hidden h-full w-px bg-gradient-to-b from-sky-500/50 via-white/10 to-transparent md:block"
+          aria-hidden
+        />
+        <ol className="space-y-6">
+          {education.map((item) => (
+            <li key={`${item.school}-${item.degree}-${item.period}`} className="group relative md:pl-12">
+              <span
+                className="absolute left-2 top-9 hidden h-3 w-3 rounded-full border-2 border-sky-400 bg-slate-950 transition group-hover:border-sky-300 group-hover:bg-sky-400/30 md:block"
+                aria-hidden
+              />
+              <Card className="border-white/10 bg-white/[0.035] p-0 shadow-[0_0_0_1px_rgba(148,163,184,0.12)] transition hover:border-sky-400/40 hover:bg-white/[0.05]">
+                <CardHeader className="mb-0 gap-3 p-6 pb-4">
+                  <div className="flex flex-wrap items-start justify-between gap-4">
+                    <CardTitle className="text-lg font-semibold text-white">
+                      {item.school}
+                    </CardTitle>
+                    <span className="flex items-center gap-2 rounded-full border border-sky-400/30 bg-sky-400/10 px-3 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-sky-100">
+                      <Calendar className="h-3.5 w-3.5" aria-hidden />
+                      {item.period}
+                    </span>
+                  </div>
+                  <CardDescription className="text-sm text-slate-300">
+                    {item.degree}
+                  </CardDescription>
+                </CardHeader>
+                {item.notes && item.notes.length > 0 ? (
+                  <CardContent className="gap-3 p-6 pt-0 text-sm text-slate-200">
+                    <ul className="space-y-2">
+                      {item.notes.map((note) => (
+                        <li key={note} className="flex gap-3 leading-relaxed">
+                          <span className="mt-2 h-1.5 w-1.5 flex-none rounded-full bg-sky-400/80" />
+                          <span>{note}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  </CardContent>
+                ) : null}
+              </Card>
+            </li>
+          ))}
+        </ol>
       </div>
     </section>
   );

--- a/src/components/home/experience-section.js
+++ b/src/components/home/experience-section.js
@@ -4,7 +4,6 @@ import {
   Card,
   CardContent,
   CardDescription,
-  CardFooter,
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
@@ -63,67 +62,61 @@ export function ExperienceSection() {
         title="Professional experience"
         description="Shaping healthcare, real estate, and HR platforms with reliable frontend and backend delivery."
       />
-      <div className="relative">
-        <div
-          className="absolute left-3 top-1 hidden h-full w-px bg-gradient-to-b from-sky-500/60 via-white/10 to-transparent md:block"
-          aria-hidden
-        />
-        <ol className="space-y-8">
-          {experiences.map((role) => (
-            <li key={`${role.company}-${role.period}`} className="group relative md:pl-12">
+      <ol className="space-y-6">
+        {experiences.map((role) => (
+          <li key={`${role.company}-${role.period}`}>
+            <Card className="relative overflow-hidden border-white/10 bg-white/[0.035] shadow-[0_0_0_1px_rgba(148,163,184,0.08)] transition hover:border-sky-400/40 hover:bg-white/[0.05]">
               <span
-                className="absolute left-2 top-12 hidden h-3 w-3 rounded-full border-2 border-sky-400 bg-slate-950 transition group-hover:border-sky-300 group-hover:bg-sky-400/30 md:block"
+                className="absolute inset-y-0 left-0 w-1 bg-gradient-to-b from-sky-400/70 via-sky-400/20 to-transparent"
                 aria-hidden
               />
-              <Card className="border-white/10 bg-white/[0.035] p-0 shadow-[0_0_0_1px_rgba(148,163,184,0.12)] transition hover:border-sky-400/40 hover:bg-white/[0.05]">
-                <CardHeader className="mb-0 gap-4 border-b border-white/5 p-6">
-                  <div className="flex flex-wrap items-start justify-between gap-4">
-                    <div className="space-y-2">
-                      <CardTitle className="text-2xl font-semibold text-white">
-                        {role.role}
-                      </CardTitle>
-                      <CardDescription className="text-sm text-slate-300">
-                        {role.company}
-                      </CardDescription>
-                    </div>
-                    <div className="flex flex-col items-end gap-2 text-right">
-                      <span className="rounded-full border border-sky-400/40 bg-sky-400/10 px-4 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-sky-100">
-                        {role.period}
-                      </span>
-                      <span className="flex items-center gap-2 text-xs font-medium text-slate-400">
-                        <MapPin className="h-4 w-4" aria-hidden />
-                        {role.location}
-                      </span>
-                    </div>
+              <div className="flex flex-col gap-6 p-5 sm:p-6 lg:p-8 md:flex-row md:items-start md:gap-8">
+                <CardHeader className="w-full space-y-4 border-b border-white/5 p-0 pb-4 md:w-64 md:border-b-0 md:border-r md:pb-0 md:pr-6">
+                  <div className="space-y-2">
+                    <CardTitle className="text-xl font-semibold leading-tight text-white">
+                      {role.role}
+                    </CardTitle>
+                    <CardDescription className="text-sm text-slate-300">
+                      {role.company}
+                    </CardDescription>
+                  </div>
+                  <div className="flex flex-col gap-2 text-xs">
+                    <span className="inline-flex items-center justify-center rounded-full border border-sky-400/40 bg-sky-400/10 px-3 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-sky-100">
+                      {role.period}
+                    </span>
+                    <span className="flex items-center gap-2 text-[0.75rem] font-medium text-slate-400">
+                      <MapPin className="h-3.5 w-3.5" aria-hidden />
+                      {role.location}
+                    </span>
                   </div>
                 </CardHeader>
-                <CardContent className="gap-5 p-6 text-sm text-slate-200">
+                <CardContent className="flex-1 space-y-4 p-0 text-sm text-slate-200">
                   <p className="text-base leading-relaxed text-slate-300">{role.summary}</p>
-                  <ul className="space-y-3">
+                  <ul className="grid gap-2 sm:grid-cols-2">
                     {role.achievements.map((item) => (
-                      <li key={item} className="flex gap-3">
-                        <span className="mt-2 h-1.5 w-1.5 flex-none rounded-full bg-sky-400/80" />
-                        <span className="leading-relaxed">{item}</span>
+                      <li key={item} className="flex items-start gap-2 leading-relaxed">
+                        <span className="mt-1 h-1.5 w-1.5 flex-none rounded-full bg-sky-400/80" />
+                        <span>{item}</span>
                       </li>
                     ))}
                   </ul>
+                  <div className="flex flex-wrap gap-2">
+                    {role.tech.map((tech) => (
+                      <Badge
+                        key={tech}
+                        variant="subtle"
+                        className="border-white/10 bg-white/10 text-[0.7rem] text-slate-100"
+                      >
+                        {tech}
+                      </Badge>
+                    ))}
+                  </div>
                 </CardContent>
-                <CardFooter className="mt-0 border-t border-white/5 bg-white/[0.02] p-6 pt-4">
-                  {role.tech.map((tech) => (
-                    <Badge
-                      key={tech}
-                      variant="subtle"
-                      className="border-white/10 bg-white/10 text-[0.7rem] text-slate-100"
-                    >
-                      {tech}
-                    </Badge>
-                  ))}
-                </CardFooter>
-              </Card>
-            </li>
-          ))}
-        </ol>
-      </div>
+              </div>
+            </Card>
+          </li>
+        ))}
+      </ol>
     </section>
   );
 }

--- a/src/components/home/experience-section.js
+++ b/src/components/home/experience-section.js
@@ -65,17 +65,17 @@ export function ExperienceSection() {
       />
       <div className="relative">
         <div
-          className="absolute left-3 top-1 hidden h-full w-px bg-gradient-to-b from-purple-500/60 via-white/10 to-transparent md:block"
+          className="absolute left-3 top-1 hidden h-full w-px bg-gradient-to-b from-sky-500/60 via-white/10 to-transparent md:block"
           aria-hidden
         />
         <ol className="space-y-8">
           {experiences.map((role) => (
             <li key={`${role.company}-${role.period}`} className="group relative md:pl-12">
               <span
-                className="absolute left-2 top-12 hidden h-3 w-3 rounded-full border-2 border-purple-400 bg-slate-950 transition group-hover:border-purple-300 group-hover:bg-purple-400/30 md:block"
+                className="absolute left-2 top-12 hidden h-3 w-3 rounded-full border-2 border-sky-400 bg-slate-950 transition group-hover:border-sky-300 group-hover:bg-sky-400/30 md:block"
                 aria-hidden
               />
-              <Card className="border-white/10 bg-white/[0.035] p-0 shadow-[0_0_0_1px_rgba(148,163,184,0.12)] transition hover:border-purple-400/40 hover:bg-white/[0.05]">
+              <Card className="border-white/10 bg-white/[0.035] p-0 shadow-[0_0_0_1px_rgba(148,163,184,0.12)] transition hover:border-sky-400/40 hover:bg-white/[0.05]">
                 <CardHeader className="mb-0 gap-4 border-b border-white/5 p-6">
                   <div className="flex flex-wrap items-start justify-between gap-4">
                     <div className="space-y-2">
@@ -87,7 +87,7 @@ export function ExperienceSection() {
                       </CardDescription>
                     </div>
                     <div className="flex flex-col items-end gap-2 text-right">
-                      <span className="rounded-full border border-purple-400/40 bg-purple-400/10 px-4 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-purple-100">
+                      <span className="rounded-full border border-sky-400/40 bg-sky-400/10 px-4 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-sky-100">
                         {role.period}
                       </span>
                       <span className="flex items-center gap-2 text-xs font-medium text-slate-400">
@@ -102,7 +102,7 @@ export function ExperienceSection() {
                   <ul className="space-y-3">
                     {role.achievements.map((item) => (
                       <li key={item} className="flex gap-3">
-                        <span className="mt-2 h-1.5 w-1.5 flex-none rounded-full bg-purple-400/80" />
+                        <span className="mt-2 h-1.5 w-1.5 flex-none rounded-full bg-sky-400/80" />
                         <span className="leading-relaxed">{item}</span>
                       </li>
                     ))}

--- a/src/components/home/experience-section.js
+++ b/src/components/home/experience-section.js
@@ -63,45 +63,66 @@ export function ExperienceSection() {
         title="Professional experience"
         description="Shaping healthcare, real estate, and HR platforms with reliable frontend and backend delivery."
       />
-      <div className="space-y-6">
-        {experiences.map((role) => (
-          <Card key={`${role.company}-${role.period}`} className="border-white/10 bg-white/[0.035]">
-            <div className="flex flex-col gap-6 md:flex-row md:items-start md:justify-between">
-              <div className="md:w-64">
-                <CardHeader className="mb-0 gap-3 p-0">
-                  <CardTitle className="text-xl text-white">{role.role}</CardTitle>
-                  <CardDescription className="text-sm text-slate-400">
-                    {role.company} · {role.period}
-                  </CardDescription>
-                  <p className="flex items-center gap-2 text-sm text-slate-400">
-                    <MapPin className="h-4 w-4" aria-hidden />
-                    {role.location}
-                  </p>
+      <div className="relative">
+        <div
+          className="absolute left-3 top-1 hidden h-full w-px bg-gradient-to-b from-purple-500/60 via-white/10 to-transparent md:block"
+          aria-hidden
+        />
+        <ol className="space-y-8">
+          {experiences.map((role) => (
+            <li key={`${role.company}-${role.period}`} className="group relative md:pl-12">
+              <span
+                className="absolute left-2 top-12 hidden h-3 w-3 rounded-full border-2 border-purple-400 bg-slate-950 transition group-hover:border-purple-300 group-hover:bg-purple-400/30 md:block"
+                aria-hidden
+              />
+              <Card className="border-white/10 bg-white/[0.035] p-0 shadow-[0_0_0_1px_rgba(148,163,184,0.12)] transition hover:border-purple-400/40 hover:bg-white/[0.05]">
+                <CardHeader className="mb-0 gap-4 border-b border-white/5 p-6">
+                  <div className="flex flex-wrap items-start justify-between gap-4">
+                    <div className="space-y-2">
+                      <CardTitle className="text-2xl font-semibold text-white">
+                        {role.role}
+                      </CardTitle>
+                      <CardDescription className="text-sm text-slate-300">
+                        {role.company}
+                      </CardDescription>
+                    </div>
+                    <div className="flex flex-col items-end gap-2 text-right">
+                      <span className="rounded-full border border-purple-400/40 bg-purple-400/10 px-4 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-purple-100">
+                        {role.period}
+                      </span>
+                      <span className="flex items-center gap-2 text-xs font-medium text-slate-400">
+                        <MapPin className="h-4 w-4" aria-hidden />
+                        {role.location}
+                      </span>
+                    </div>
+                  </div>
                 </CardHeader>
-              </div>
-              <div className="flex-1">
-                <CardContent className="gap-4 p-0 text-sm text-slate-200">
-                  <p className="text-slate-300">{role.summary}</p>
+                <CardContent className="gap-5 p-6 text-sm text-slate-200">
+                  <p className="text-base leading-relaxed text-slate-300">{role.summary}</p>
                   <ul className="space-y-3">
                     {role.achievements.map((item) => (
                       <li key={item} className="flex gap-3">
-                        <span className="mt-2 h-1.5 w-1.5 flex-none rounded-full bg-sky-400" />
+                        <span className="mt-2 h-1.5 w-1.5 flex-none rounded-full bg-purple-400/80" />
                         <span className="leading-relaxed">{item}</span>
                       </li>
                     ))}
                   </ul>
                 </CardContent>
-              </div>
-            </div>
-            <CardFooter className="mt-8 border-t border-white/5 pt-4">
-              {role.tech.map((tech) => (
-                <Badge key={tech} variant="subtle" className="text-xs">
-                  {tech}
-                </Badge>
-              ))}
-            </CardFooter>
-          </Card>
-        ))}
+                <CardFooter className="mt-0 border-t border-white/5 bg-white/[0.02] p-6 pt-4">
+                  {role.tech.map((tech) => (
+                    <Badge
+                      key={tech}
+                      variant="subtle"
+                      className="border-white/10 bg-white/10 text-[0.7rem] text-slate-100"
+                    >
+                      {tech}
+                    </Badge>
+                  ))}
+                </CardFooter>
+              </Card>
+            </li>
+          ))}
+        </ol>
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary
- restyle the education section into a vertical timeline with highlighted period badges and refined note bullets
- rework the experience section into a timeline layout with clearer role/company hierarchy and improved tech stack footer styling

## Testing
- npm run build *(fails: next/font cannot download Google Fonts in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cae4618330832584d62be1d9f655e5