### PR TITLE
Center skill and language icons

### DIFF
--- a/src/components/home/languages-section.js
+++ b/src/components/home/languages-section.js
@@ -1,10 +1,11 @@
 import { SectionHeader } from "@/components/section-header";
 import { Card } from "@/components/ui/card";
+import { BookOpen, Globe, MessageCircle } from "lucide-react";
 
 const languages = [
-  { name: "English", level: "Fluent" },
-  { name: "Arabic", level: "Native" },
-  { name: "French", level: "Intermediate" },
+  { name: "English", level: "Fluent", icon: MessageCircle },
+  { name: "Arabic", level: "Native", icon: BookOpen },
+  { name: "French", level: "Intermediate", icon: Globe },
 ];
 
 export function LanguagesSection() {
@@ -16,13 +17,16 @@ export function LanguagesSection() {
         description="Comfortable collaborating across English, Arabic, and French-speaking teams."
       />
       <div className="grid gap-3 sm:grid-cols-2 md:grid-cols-3">
-        {languages.map((language) => (
+        {languages.map(({ name, level, icon: Icon }) => (
           <Card
-            key={language.name}
-            className="border-white/10 bg-white/[0.04] p-4 text-center text-sm text-slate-200"
+            key={name}
+            className="flex flex-col items-center gap-3 border-white/10 bg-white/[0.04] p-4 text-center text-sm text-slate-200"
           >
-            <div className="text-base font-semibold text-white">{language.name}</div>
-            <div className="text-xs uppercase tracking-[0.2em] text-slate-400">{language.level}</div>
+            <span className="flex h-12 w-12 items-center justify-center rounded-full bg-sky-400/10 text-sky-400">
+              <Icon className="h-6 w-6" aria-hidden />
+            </span>
+            <div className="text-base font-semibold text-white">{name}</div>
+            <div className="text-xs uppercase tracking-[0.2em] text-slate-400">{level}</div>
           </Card>
         ))}
       </div>

--- a/src/components/home/skills-section.js
+++ b/src/components/home/skills-section.js
@@ -66,10 +66,10 @@ export function SkillsSection() {
         {skills.map(({ name, icon: Icon }) => (
           <Card
             key={name}
-            className="flex items-center gap-3 border-white/10 bg-white/[0.04] p-4 text-left text-sm font-medium text-slate-200"
+            className="flex flex-col items-center gap-3 border-white/10 bg-white/[0.04] p-4 text-center text-sm font-medium text-slate-200"
           >
-            <span className="flex h-10 w-10 items-center justify-center rounded-full bg-sky-400/10 text-sky-400">
-              <Icon className="h-5 w-5" aria-hidden />
+            <span className="flex h-12 w-12 items-center justify-center rounded-full bg-sky-400/10 text-sky-400">
+              <Icon className="h-6 w-6" aria-hidden />
             </span>
             <span>{name}</span>
           </Card>


### PR DESCRIPTION
## Summary
- center the icons in the skill cards by stacking the symbol above the label
- add icons to each language card and align them with the skill card styling

## Testing
- npm run build *(fails: Next.js cannot download Google Fonts in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cae43b301483259092c84f66b03107